### PR TITLE
Prevent file-level comments from being confused with package godoc

### DIFF
--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -13,6 +13,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
 // Buildifier, a tool to parse and format BUILD files.
 package main
 

--- a/core/lex.go
+++ b/core/lex.go
@@ -11,9 +11,10 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 // Lexical scanning for BUILD file parser.
+
 package build
 
 //go:generate go tool yacc -o parse.y.go parse.y

--- a/core/parse_test.go
+++ b/core/parse_test.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 package build
 
 import (

--- a/core/print.go
+++ b/core/print.go
@@ -11,9 +11,10 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 // Printing of syntax trees.
+
 package build
 
 import (

--- a/core/print_test.go
+++ b/core/print_test.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 package build
 
 import (

--- a/core/quote.go
+++ b/core/quote.go
@@ -11,9 +11,10 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 // Python quoted strings.
+
 package build
 
 import (

--- a/core/quote_test.go
+++ b/core/quote_test.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 package build
 
 import (

--- a/core/rewrite.go
+++ b/core/rewrite.go
@@ -11,9 +11,10 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 // Rewriting of high-level (not purely syntactic) BUILD constructs.
+
 package build
 
 import (

--- a/core/rule.go
+++ b/core/rule.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 // Rule-level API for inspecting and modifying a build.File syntax tree.
 
 package build

--- a/core/syntax.go
+++ b/core/syntax.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 // Package build implements parsing and printing of BUILD files.
 package build
 

--- a/core/tables.go
+++ b/core/tables.go
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
 // Tables about what Buildifier can and cannot edit.
 // Perhaps eventually this will be

--- a/core/walk.go
+++ b/core/walk.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 package build
 
 // Walk walks the expression tree v, calling f on all subexpressions

--- a/differ/diff.go
+++ b/differ/diff.go
@@ -11,8 +11,9 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
- limitations under the License. 
+ limitations under the License.
 */
+
 // Package differ determines how to invoke diff in the given environment.
 package differ
 


### PR DESCRIPTION
It improves the package documentation in https://godoc.org/github.com/bazelbuild/buildifier/core