### PR TITLE
fix rendering of MarkDown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Note: the extra 'generate' step as 'go get' does not run 'generate' when install
 Use buildifier to create standardized formatting for BUILD files in the
 same way that clang-format is used for source files.
 
-`$ buildifier -showlog -mode=check `find . -iname BUILD -type f`
+`$ buildifier -showlog -mode=check $(find . -iname BUILD -type f)`


### PR DESCRIPTION
There is a missing ` at the end of the buildifier command that is
breaking the layout when GitHub renders the README.md file.

Instead, just use the syntax $() to fix this problem.