### PR TITLE
Allow forcing multiline for dict and tuple comprehensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/bazel-bin
+/bazel-buildifier
+/bazel-genfiles
+/bazel-out
+/bazel-testlogs

--- a/core/parse.y
+++ b/core/parse.y
@@ -255,6 +255,7 @@ expr:
 	}
 |	'(' expr for_clauses if_clauses_opt ')'
 	{
+		exprStart, _ := $2.Span()
 		$$ = &ListForExpr{
 			Brack: "()",
 			Start: $1,
@@ -262,10 +263,12 @@ expr:
 			For: $3,
 			If: $4,
 			End: End{Pos: $5},
+			ForceMultiLine: $1.Line != exprStart.Line,
 		}
 	}
 |	'{' keyvalue for_clauses if_clauses_opt '}'
 	{
+		exprStart, _ := $2.Span()
 		$$ = &ListForExpr{
 			Brack: "{}",
 			Start: $1,
@@ -273,6 +276,7 @@ expr:
 			For: $3,
 			If: $4,
 			End: End{Pos: $5},
+			ForceMultiLine: $1.Line != exprStart.Line,
 		}
 	}
 |	'{' keyvalues_opt '}'

--- a/core/print_test.go
+++ b/core/print_test.go
@@ -168,7 +168,7 @@ func (eq *eqchecker) checkValue(v, w reflect.Value) error {
 	// if v is a non-nil interface value, it returns the concrete
 	// value in the interface.
 	inner := func(v reflect.Value) reflect.Value {
-		for {
+		for v.IsValid() {
 			if v.Type() == parenType {
 				v = v.Elem().FieldByName("X")
 				continue
@@ -184,6 +184,15 @@ func (eq *eqchecker) checkValue(v, w reflect.Value) error {
 
 	v = inner(v)
 	w = inner(w)
+
+	if v.Kind() != w.Kind() {
+		return eq.errorf("%s became %s", v.Kind(), w.Kind())
+	}
+
+	// There is nothing to compare for zero values, so exit early.
+	if !v.IsValid() {
+		return nil
+	}
 
 	if v.Type() != w.Type() {
 		return eq.errorf("%s became %s", v.Type(), w.Type())

--- a/core/testdata/043.golden
+++ b/core/testdata/043.golden
@@ -1,0 +1,4 @@
+bar = "bar"
+
+# This gets an empty expr_opt in the parser, causing a nil to appear.
+b = bar[:-2]

--- a/core/testdata/043.in
+++ b/core/testdata/043.in
@@ -1,0 +1,3 @@
+bar = "bar"
+# This gets an empty expr_opt in the parser, causing a nil to appear.
+b = bar[:-2]

--- a/core/testdata/044.golden
+++ b/core/testdata/044.golden
@@ -1,0 +1,18 @@
+# The comprehensions here shouldn't get collapsed to single lines.
+
+GLOB_resources_legacy_txt = glob(["resources/legacy/*.txt"])
+
+GLOB_resources_legacy_txt2 = [
+    filename_and_some_extra_to_make_this_long
+    for filename_and_some_extra_to_make_this_long in GLOB_resources_legacy_txt
+]
+
+GLOB_resources_legacy_txt_tuple = (
+    filename_and_some_extra_to_make_this_long
+    for filename_and_some_extra_to_make_this_long in GLOB_resources_legacy_txt
+)
+
+legacy_txt_name_to_filename = {
+    filename.split("/")[-1][:-len(".txt")].lower(): filename
+    for filename in GLOB_resources_legacy_txt_tuple
+}

--- a/core/testdata/044.in
+++ b/core/testdata/044.in
@@ -1,0 +1,18 @@
+# The comprehensions here shouldn't get collapsed to single lines.
+
+GLOB_resources_legacy_txt = glob(["resources/legacy/*.txt"])
+
+GLOB_resources_legacy_txt2 = [
+  filename_and_some_extra_to_make_this_long
+  for filename_and_some_extra_to_make_this_long in GLOB_resources_legacy_txt
+]
+
+GLOB_resources_legacy_txt_tuple = (
+  filename_and_some_extra_to_make_this_long
+  for filename_and_some_extra_to_make_this_long in GLOB_resources_legacy_txt
+)
+
+legacy_txt_name_to_filename = {
+  filename.split("/")[-1][:-len(".txt")].lower(): filename
+  for filename in GLOB_resources_legacy_txt_tuple
+}


### PR DESCRIPTION
Also:
* Add .gitignore, as spurious files started appearing in `git status`.
* Fix a panic in the test caused by using `[:len(".txt")]` in the testdata, which creates a zero value for `reflect` on which `Type()` cannot be called.

It'd be nice if long comprehensions would be broken automatically, but being able to force this takes away the immediate pain.