### PR TITLE
Reference rules_go using reliable http_archive()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 Paul Bethe <pbethe@google.com>
 Laurent Le Brun <laurentlb@google.com>
 Nilton Volpato <nilton@google.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,12 @@
 workspace(name = "com_github_bazelbuild_buildifier")
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.2.0",
+    sha256 = "0c0ec7b9c7935883cbfb2df48fbf524e857859a5c05ae1b24d5442956e6bb5e8",
+    strip_prefix = "rules_go-0.2.0",
+    url = "http://bazel-mirror.storage.googleapis.com/github.com/bazelbuild/rules_go/archive/0.2.0.tar.gz",
 )
+
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
 go_repositories()


### PR DESCRIPTION
Fetching via git is slow, buggy, and wastes disk space. It caused a problem for a TensorFlow user in tensorflow/tensorflow#4999. Using http_archive is the optimal solution. I've slowly but surely been updating all the Bazel projects to follow this practice. I've also taken the liberty of mirroring this file for additional reliability.