### PR TITLE
use x/tools/cmd/goyacc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,7 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_go/archive/0.3.1.tar.gz",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+load("@io_bazel_rules_go//go:def.bzl", "go_repositories", "new_go_repository")
 load("@io_bazel_rules_go//proto:go_proto_library.bzl", "go_proto_repositories")
 
 go_repositories()
@@ -20,4 +20,10 @@ http_archive(
     sha256 = "8e4646898fa9298422e69767752680d34cbf21bcae01c401b11aa74fcdb0ef66",
     strip_prefix = "bazel-0.4.1",
     url = "https://github.com/bazelbuild/bazel/archive/0.4.1.tar.gz",
+)
+
+new_go_repository(
+    name = "org_golang_x_tools",
+    commit = "3d92dd60033c312e3ae7cac319c792271cf67e37",
+    importpath = "golang.org/x/tools",
 )

--- a/core/build_defs.bzl
+++ b/core/build_defs.bzl
@@ -15,7 +15,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
  limitations under the License.
 """
 
-_GO_TOOL = "@io_bazel_rules_go//go/toolchain:go_tool"
+_GO_YACC_TOOL = "@org_golang_x_tools//cmd/goyacc"
 
 def go_yacc(src, out, visibility=None):
   """Runs go tool yacc -o $out $src."""
@@ -23,9 +23,9 @@ def go_yacc(src, out, visibility=None):
       name = src + ".go_yacc",
       srcs = [src],
       outs = [out],
-      tools = [_GO_TOOL],
-      cmd = ("export GOROOT=$$(dirname $(location " + _GO_TOOL + "))/..;" +
-             " $(location " + _GO_TOOL + ") tool yacc " +
+      tools = [_GO_YACC_TOOL],
+      cmd = ("export GOROOT=$$(dirname $(location " + _GO_YACC_TOOL + "))/..;" +
+             " $(location " + _GO_YACC_TOOL + ") " +
              " -o $(location " + out + ") $(SRCS)"),
       visibility = visibility,
       local = 1,


### PR DESCRIPTION
Removes the dependency on `go tool yacc` which is going away in Go 1.8.

Fixes #23