### PR TITLE
Introduce a -tables option.

### DIFF
--- a/buildifier/BUILD.bazel
+++ b/buildifier/BUILD.bazel
@@ -7,5 +7,6 @@ go_binary(
     deps = [
         "//build:go_default_library",
         "//differ:go_default_library",
+        "//tables:go_default_library",
     ],
 )

--- a/buildifier/buildifier.go
+++ b/buildifier/buildifier.go
@@ -29,16 +29,18 @@ import (
 
 	"github.com/bazelbuild/buildifier/build"
 	"github.com/bazelbuild/buildifier/differ"
+	"github.com/bazelbuild/buildifier/tables"
 )
 
 var (
 	// Undocumented; for debugging.
 	showlog = flag.Bool("showlog", false, "show log in check mode")
 
-	vflag = flag.Bool("v", false, "print verbose information on standard error")
-	dflag = flag.Bool("d", false, "alias for -mode=diff")
-	mode  = flag.String("mode", "", "formatting mode: check, diff, or fix (default fix)")
-	path  = flag.String("path", "", "assume BUILD file has this path relative to the workspace directory")
+	vflag      = flag.Bool("v", false, "print verbose information on standard error")
+	dflag      = flag.Bool("d", false, "alias for -mode=diff")
+	mode       = flag.String("mode", "", "formatting mode: check, diff, or fix (default fix)")
+	path       = flag.String("path", "", "assume BUILD file has this path relative to the workspace directory")
+	tablesPath = flag.String("tables", "", "path to JSON file with custom table definitions")
 
 	// Debug flags passed through to rewrite.go
 	allowSort = stringList("allowsort", "additional sort contexts to treat as safe")
@@ -111,6 +113,13 @@ func main() {
 	if *path != "" && len(args) > 1 {
 		fmt.Fprintf(os.Stderr, "buildifier: can only format one file when using -path flag\n")
 		os.Exit(2)
+	}
+
+	if *tablesPath != "" {
+		if err := tables.ParseAndUpdateJsonDefinitions(*tablesPath); err != nil {
+			fmt.Fprintf(os.Stderr, "buildifier: failed to parse %s for -tables: %s\n", *tablesPath, err)
+			os.Exit(2)
+		}
 	}
 
 	diff = differ.Find()

--- a/tables/BUILD.bazel
+++ b/tables/BUILD.bazel
@@ -1,7 +1,20 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["tables.go"],
+    srcs = [
+        "jsonparser.go",
+        "tables.go",
+    ],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "jsonparser_test.go",
+    ],
+    data = glob(["testdata/*"]),
+    library = ":go_default_library",
 )

--- a/tables/jsonparser.go
+++ b/tables/jsonparser.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package tables
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+type Definitions struct {
+	IsLabelArg        map[string]bool
+	LabelBlacklist    map[string]bool
+	IsSortableListArg map[string]bool
+	SortableBlacklist map[string]bool
+	SortableWhitelist map[string]bool
+}
+
+func ParseJsonDefinitions(file string) (Definitions, error) {
+	var definitions Definitions
+
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return definitions, err
+	}
+
+	err = json.Unmarshal(data, &definitions)
+	return definitions, err
+}
+
+func ParseAndUpdateJsonDefinitions(file string) error {
+	definitions, err := ParseJsonDefinitions(file)
+	if err != nil {
+		return err
+	}
+
+	OverrideTables(definitions.IsLabelArg, definitions.LabelBlacklist, definitions.IsSortableListArg, definitions.SortableBlacklist, definitions.SortableWhitelist)
+	return nil
+}

--- a/tables/jsonparser_test.go
+++ b/tables/jsonparser_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package tables
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseJsonDefinitions(t *testing.T) {
+	testdata := os.Getenv("TEST_SRCDIR") + "/" + os.Getenv("TEST_WORKSPACE") + "/tables/testdata"
+	definitions, err := ParseJsonDefinitions(testdata + "/simple_tables.json")
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := Definitions{
+		IsLabelArg:        map[string]bool{"srcs": true},
+		LabelBlacklist:    map[string]bool{},
+		IsSortableListArg: map[string]bool{"srcs": true, "visibility": true},
+		SortableBlacklist: map[string]bool{"genrule.srcs": true},
+		SortableWhitelist: map[string]bool{},
+	}
+	if !reflect.DeepEqual(expected, definitions) {
+		t.Errorf("ParseJsonDefinitions() = %v; want %v", definitions, expected)
+	}
+}

--- a/tables/testdata/simple_tables.json
+++ b/tables/testdata/simple_tables.json
@@ -1,0 +1,19 @@
+{
+  "i-am-an-unrelated-field": true,
+  "IsLabelArg": {
+    "srcs": true
+  },
+  "LabelBlacklist": {
+
+  },
+  "IsSortableListArg": {
+    "srcs": true,
+    "visibility": true
+  },
+  "SortableBlacklist": {
+    "genrule.srcs": true
+  },
+  "SortableWhitelist": {
+
+  }
+}


### PR DESCRIPTION
The `-tables` option makes it possible to specify a JSON file whose
properties define arguments that will be passed to the
`tables.OverrideTables()` function such that other projects can define
their own constraints on argument formatting. This is valuable to
Buck or Skylark users that define rules that need to be formatted in a
way that is different from buildifier's defaults.

Test Plan:
* Added a test: `tables/jsonParser_test.go`.
* Verified that `bazel test //...` succeeds.
* Created a JSON config for Buck and verified the output of the
following was what I expected when run from the Buck repo:

```
export BUILDIFIER_DIFF="diff -u"
find . -name BUCK | xargs -I {} ../buildifier/bazel-bin/buildifier/buildifier -buildifier_disable=label -tables=buildifier.json -d {}
```

For this test, the contents of `buildifier.json` were:

```
{
  "IsLabelArg": {
  },
  "LabelBlacklist": {
  },
  "IsSortableListArg": {
    "deps": true,
    "exported_deps": true,
    "provided_deps": true,
    "srcs": true,
    "visibility": true
  },
  "SortableBlacklist": {
    "genrule.srcs": true
  },
  "SortableWhitelist": {
  }
}
```