### PR TITLE
Make buildifier and buildozer compile on Windows

### DIFF
--- a/differ/BUILD.bazel
+++ b/differ/BUILD.bazel
@@ -2,6 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["diff.go"],
+    srcs = [
+        "diff.go",
+        "isatty_darwin.go",
+        "isatty_linux.go",
+        "isatty_windows.go",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/differ/diff.go
+++ b/differ/diff.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 )
 
 // Invocation of different diff commands, according to environment variables.
@@ -116,15 +115,4 @@ func Find() *Differ {
 		}
 	}
 	return d
-}
-
-// isatty reports whether fd is a tty.
-// Actually it reports whether fd is a character device, which is close enough.
-func isatty(fd int) bool {
-	var st syscall.Stat_t
-	err := syscall.Fstat(fd, &st)
-	if err != nil {
-		return false
-	}
-	return st.Mode&syscall.S_IFMT == syscall.S_IFCHR
 }

--- a/differ/isatty_darwin.go
+++ b/differ/isatty_darwin.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package differ
+
+import "syscall"
+
+// isatty reports whether fd is a tty.
+// Actually it reports whether fd is a character device, which is close enough.
+func isatty(fd int) bool {
+	var st syscall.Stat_t
+	err := syscall.Fstat(fd, &st)
+	if err != nil {
+		return false
+	}
+	return st.Mode&syscall.S_IFMT == syscall.S_IFCHR
+}

--- a/differ/isatty_darwin.go
+++ b/differ/isatty_darwin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Google Inc. All Rights Reserved.
+Copyright 2017 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,8 +22,7 @@ import "syscall"
 // Actually it reports whether fd is a character device, which is close enough.
 func isatty(fd int) bool {
 	var st syscall.Stat_t
-	err := syscall.Fstat(fd, &st)
-	if err != nil {
+	if err := syscall.Fstat(fd, &st); err != nil {
 		return false
 	}
 	return st.Mode&syscall.S_IFMT == syscall.S_IFCHR

--- a/differ/isatty_linux.go
+++ b/differ/isatty_linux.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package differ
+
+import "syscall"
+
+// isatty reports whether fd is a tty.
+// Actually it reports whether fd is a character device, which is close enough.
+func isatty(fd int) bool {
+	var st syscall.Stat_t
+	err := syscall.Fstat(fd, &st)
+	if err != nil {
+		return false
+	}
+	return st.Mode&syscall.S_IFMT == syscall.S_IFCHR
+}

--- a/differ/isatty_linux.go
+++ b/differ/isatty_linux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Google Inc. All Rights Reserved.
+Copyright 2017 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,8 +22,7 @@ import "syscall"
 // Actually it reports whether fd is a character device, which is close enough.
 func isatty(fd int) bool {
 	var st syscall.Stat_t
-	err := syscall.Fstat(fd, &st)
-	if err != nil {
+	if err := syscall.Fstat(fd, &st); err != nil {
 		return false
 	}
 	return st.Mode&syscall.S_IFMT == syscall.S_IFCHR

--- a/differ/isatty_windows.go
+++ b/differ/isatty_windows.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 Google Inc. All Rights Reserved.
+Copyright 2017 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/differ/isatty_windows.go
+++ b/differ/isatty_windows.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package differ
+
+// isatty reports whether fd is a tty.
+// On Windows we just say no.
+func isatty(fd int) bool {
+	return false
+}


### PR DESCRIPTION
Without this commit, a build on Windows fails with:

```
differ\diff.go:124 undefined: syscall.Stat_t
```

I had initially tried to use two files and avoid having one file per OS:

1. `isatty_other.go` with `// +build !windows`
2. `isatty_windows.go`

But [build constraints](https://golang.org/pkg/go/build/#hdr-Build_Constraints) require that they be preceded only by line comments or blank lines, they cannot be preceded by the [general comments](https://golang.org/ref/spec#Comments) (`/* ... */`) which are used in the files in this repository.