### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build the tool:
 * Checkout the repo and then either via `go install` or `bazel build //buildifier`
 * If you already have 'go' installed, then build a binary via: 
 
-`go install github.com/bazelbuild/buildifier/buildifier`
+`go get github.com/bazelbuild/buildifier/buildifier`
 
 ## Usage
 


### PR DESCRIPTION
In case if `go` is already installed `go get` could be used to setup local buildifier